### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirement : <br />
 pip install apscheduler <br />
 Redis 5.0.7 (pip install redis)   :  DB server used for communication between AIs and user , require additionnal downloads to run the Redis server.  <br />
 tenacity-9.0.0 (pip install tenacity) <br />
-pyautogen-0.2.33 (pip install --upgrade pyautogen) <br />
+ag2-0.2.33 (pip install --upgrade ag2) <br />
 openai-1.40.0 (pip install --upgrade openai) <br />
 pip install openai_multi_tool_use_parallel_patch <br />
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reflect the new package name for a Python dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->